### PR TITLE
Update snap packaging

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+# copy all the examples into $SNAP_DATA
+cp -r "$SNAP/examples" "$SNAP_DATA/examples"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,6 +19,8 @@ apps:
   edgex-device-rpi:
     command: bin/device-rpi
     plugs:
+      - home
+      - removable-media
       - network
       - network-bind
       - gpio

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,7 +17,7 @@ confinement: strict
 
 apps:
   edgex-device-rpi:
-    command: bin/device-rpi --registry --confdir $SNAP_DATA/config/configuration.toml
+    command: bin/device-rpi
     plugs:
       - network
       - network-bind

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,30 +24,25 @@ apps:
       - gpio
 
 parts:
-  config:
+  examples:
     source: .
     plugin: dump
     organize:
-      res/configuration.toml: config/configuration.toml
       LICENSE: usr/share/doc/edgex-device-rpi/LICENSE
-    override-build: |
-      snapcraftctl build
-      # change the host specifications to be localhost for the snap
-      sed -i \
-        -e s'@Host = \"edgex-device-rpi\"@Host = \"localhost\"@' \
-        -e s'@Host = \"edgex-core-data\"@Host = \"localhost\"@' \
-        -e s'@Host = \"edgex-core-metadata\"@Host = \"localhost\"@' \
-        $SNAPCRAFT_PART_INSTALL/res/configuration.toml
-    stage: [-*]
     prime: 
-      - config/configuration.toml
+      - examples/*
+      - usr/share/doc/edgex-device-rpi/LICENSE
+    stage: 
+      - examples/*
       - usr/share/doc/edgex-device-rpi/LICENSE
   stage-patches:
     source: .
+    after: [examples]
     plugin: dump
+    organize:
+      LICENSE: usr/share/doc/edgex-device-rpi/LICENSE
     prime: [-*]
     stage: [scripts/rpi_patch]
-    after: [config]
   libmraa:
     source: https://github.com/intel-iot-devkit/mraa.git
     source-commit: d320776

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,7 +16,7 @@ grade: stable
 confinement: strict
 
 apps:
-  device-rpi:
+  edgex-device-rpi:
     command: bin/device-rpi --registry --confdir $SNAP_DATA/config/configuration.toml
     plugs:
       - network


### PR DESCRIPTION
* Add the `examples` dir into the snap
* Don't copy the `config` dir into the snap
* Copy the `examples` dir into $SNAP_DATA so it can easily be modified
* Rename app so that it can be called with the snap name directly i.e. `edgex-device-rpi`
* Remove default args to the app so that the user can specify them when using as an app
* Add home, removable-media plugs so that the user can put configuration files into their home folder and run it from there (note that this will require being able to access gpio as non-root, otherwise running the app as root here will only grant access to root's $HOME folder